### PR TITLE
Fix RE_VAR_FUNC for fallback.

### DIFF
--- a/lib/resolve-value.js
+++ b/lib/resolve-value.js
@@ -10,7 +10,7 @@ var cloneSpliceParentOntoNodeWhen = require('./clone-splice-parent-onto-node-whe
 // var() = var( <custom-property-name> [, <any-value> ]? )
 // matches `name[, fallback]`, captures "name" and "fallback"
 // See: http://dev.w3.org/csswg/css-variables/#funcdef-var
-var RE_VAR_FUNC = (/var\((--[^,\s]+?)(?:\s*,\s*(.+))?\)/);
+var RE_VAR_FUNC = (/var\((--[^,\s]+?)(?:\s*,\s*(.+?))?\)/);
 
 // Pass in a value string to parse/resolve and a map of available values
 // and we can figure out the final value

--- a/test/fixtures/missing-variable-as-function-argument.css
+++ b/test/fixtures/missing-variable-as-function-argument.css
@@ -1,0 +1,3 @@
+div {
+	background-color: color(var(--foo-color, #fff) alpha(0.5));
+}

--- a/test/fixtures/missing-variable-as-function-argument.expected.css
+++ b/test/fixtures/missing-variable-as-function-argument.expected.css
@@ -1,0 +1,3 @@
+div {
+	background-color: color(#fff alpha(0.5));
+}

--- a/test/fixtures/missing-variable-two-vars.css
+++ b/test/fixtures/missing-variable-two-vars.css
@@ -1,0 +1,3 @@
+div {
+	border: var(--foo-br-style, solid) var(--foo-color, red);
+}

--- a/test/fixtures/missing-variable-two-vars.expected.css
+++ b/test/fixtures/missing-variable-two-vars.expected.css
@@ -1,0 +1,3 @@
+div {
+	border: solid red;
+}

--- a/test/fixtures/variable-with-fallback-as-function.css
+++ b/test/fixtures/variable-with-fallback-as-function.css
@@ -1,0 +1,4 @@
+div {
+	--foo-color: #fff;
+	background-color: var(--foo-color, rgb(0, 0, 0));
+}

--- a/test/fixtures/variable-with-fallback-as-function.expected.css
+++ b/test/fixtures/variable-with-fallback-as-function.expected.css
@@ -1,0 +1,3 @@
+div {
+	background-color: #fff;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -129,6 +129,11 @@ describe('postcss-css-variables', function() {
 	);
 
 	test(
+		'should work with variable when the fallback is a function',
+		'variable-with-fallback-as-function'
+	);
+
+	test(
 		'should work with variables that reference other variables with at-rule changing the value',
 		'variable-reference-other-variable-media-query1'
 	);
@@ -180,6 +185,8 @@ describe('postcss-css-variables', function() {
 	describe('missing variable declarations', function() {
 		test('should work with missing variables', 'missing-variable-usage');
 		test('should use fallback value if provided with missing variables', 'missing-variable-should-fallback');
+		test('should work as function arguments', 'missing-variable-as-function-argument');
+		test('should work with two consecutive vars', 'missing-variable-two-vars');
 	});
 
 	it('should not parse malformed var() declarations', function() {


### PR DESCRIPTION
Given `var(--me, 1) a()` the first group would have been `--me` and the
second group `1) a(` which is wrong. With this fix the second group is
correctly matched as `1`.

This should fix #23.