### PR TITLE
Update Node.js Versions for Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - iojs
+  - "iojs"
+  - "stable"
+  - "4.2"
   - "0.12"
-  - "0.10"


### PR DESCRIPTION
Maybe iojs, 0.10 and 0.12 should be dropped?