### PR TITLE
Providing undefined as a string

### DIFF
--- a/lib/resolve-decl.js
+++ b/lib/resolve-decl.js
@@ -144,6 +144,14 @@ function resolveDecl(decl, map, /*optional*/shouldPreserve, /*optional*/logResol
 		decl.cloneAfter();
 	}
 
+
+	// Set 'undefined' value as a string to avoid making other plugins down the line unhappy
+	// See #22
+	if (valueResults.value === undefined) {
+		valueResults.value = 'undefined';
+	}
+
+
 	// Set the new value after we are done dealing with at-rule stuff
 	decl.value = valueResults.value;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -186,6 +186,25 @@ describe('postcss-css-variables', function() {
 	describe('missing variable declarations', function() {
 		test('should work with missing variables', 'missing-variable-usage');
 		test('should use fallback value if provided with missing variables', 'missing-variable-should-fallback');
+		it('should use string values for `undefined` values, see #22', function() {
+			return fs.readFileAsync('./test/fixtures/missing-variable-usage.css', 'utf8')
+				.then(function(buffer) {
+					var contents = String(buffer);
+						return postcss([
+							cssvariables()
+						])
+						.process(contents)
+						.then(function(result) {
+							var root = result.root;
+							var fooRule = root.nodes[0];
+							expect(fooRule.selector).to.equal('.box-foo');
+							var colorDecl = fooRule.nodes[0];
+							expect(colorDecl.value).to.be.a('string');
+							expect(colorDecl.value).to.be.equal('undefined');
+							return colorDecl.value;
+						});
+					});
+		});
 	});
 
 	it('should not parse malformed var() declarations', function() {
@@ -206,6 +225,5 @@ describe('postcss-css-variables', function() {
 			'remove-nested-empty-rules-after-variable-collection'
 		);
 	});
-
 
 });


### PR DESCRIPTION
Fix #22

This resolves the issues I was testing in #22 where an undefined variable broke other plugins by providing an `undefined` variable instead of a variable with the value of `"undefined"`.

Don’t really know what tests to add because the output will be the same in this plugin context. But if you have an idea I could add something! 👍 