### PR TITLE
Resolve `var` usage in fallbacks

### DIFF
--- a/lib/resolve-value.js
+++ b/lib/resolve-value.js
@@ -61,10 +61,11 @@ var resolveValue = function(decl, map, /*optional*/ignorePseudoScope, /*internal
 			}
 		});
 
-		var fallbackValue;
+		// Resolve values in fallback
+		var fallbackValue = fallback;
 		if(fallback) {
-			var cloneDecl = Object.assign({},decl,{value:fallback});
-			fallbackValue = resolveValue(cloneDecl, map, false,true).value;
+			var fallbackDecl = decl.clone({ parent: decl.parent, value: fallback });
+			fallbackValue = resolveValue(fallbackDecl, map, false, true).value;
 		}
 
 		// Default to the calculatedInPlaceValue which might be a previous fallback, then try this declarations fallback

--- a/lib/resolve-value.js
+++ b/lib/resolve-value.js
@@ -61,8 +61,14 @@ var resolveValue = function(decl, map, /*optional*/ignorePseudoScope, /*internal
 			}
 		});
 
+		var fallbackValue;
+		if(fallback) {
+			var cloneDecl = Object.assign({},decl,{value:fallback});
+			fallbackValue = resolveValue(cloneDecl, map, false,true).value;
+		}
+
 		// Default to the calculatedInPlaceValue which might be a previous fallback, then try this declarations fallback
-		var replaceValue = (matchingVarDeclMapItem || {}).calculatedInPlaceValue || fallback;
+		var replaceValue = (matchingVarDeclMapItem || {}).calculatedInPlaceValue || fallbackValue;
 		// Otherwise if the dependency health is good(no circular or self references), dive deeper and resolve
 		if(matchingVarDeclMapItem !== undefined && !gatherVariableDependencies(variablesUsedInValue, map).hasCircularOrSelfReference) {
 			// Splice the declaration parent onto the matching entry

--- a/test/fixtures/missing-variable-should-fallback-calc.css
+++ b/test/fixtures/missing-variable-should-fallback-calc.css
@@ -1,0 +1,7 @@
+:root {
+    --foo1: 150px;
+}
+
+.box-bar {
+     width: var(--missing,calc(var(--foo1) + 100px));
+}

--- a/test/fixtures/missing-variable-should-fallback-calc.expected.css
+++ b/test/fixtures/missing-variable-should-fallback-calc.expected.css
@@ -1,0 +1,3 @@
+.box-bar {
+     width: calc(150px + 100px);
+}

--- a/test/fixtures/missing-variable-should-fallback-nested.css
+++ b/test/fixtures/missing-variable-should-fallback-nested.css
@@ -1,0 +1,8 @@
+:root {
+    --foo1: 100px;
+    --foo2: 150px;
+}
+
+.box-bar {
+     width: var(--missing, var(--missing, var(--foo1)));
+}

--- a/test/fixtures/missing-variable-should-fallback-nested.expected.css
+++ b/test/fixtures/missing-variable-should-fallback-nested.expected.css
@@ -1,0 +1,3 @@
+.box-bar {
+     width: 100px;
+}

--- a/test/fixtures/missing-variable-should-fallback-var.css
+++ b/test/fixtures/missing-variable-should-fallback-var.css
@@ -1,0 +1,12 @@
+:root {
+    --foo-default: 100px;
+    --foo-width: 150px;
+}
+
+.box-foo {
+    width: var(--missing);
+}
+
+.box-bar {
+    width: var(--missing, var(--foo-default));
+}

--- a/test/fixtures/missing-variable-should-fallback-var.expected.css
+++ b/test/fixtures/missing-variable-should-fallback-var.expected.css
@@ -1,0 +1,7 @@
+.box-foo {
+    width: undefined;
+}
+
+.box-bar {
+    width: 100px;
+}

--- a/test/fixtures/missing-variable-should-fallback.css
+++ b/test/fixtures/missing-variable-should-fallback.css
@@ -1,11 +1,6 @@
 :root {
 	--foo-width: 150px;
 }
-
-.box-foo {
-	width: var(--missing);
-}
-
 .box-bar {
 	width: var(--missing, 30px);
 }

--- a/test/fixtures/missing-variable-should-fallback.expected.css
+++ b/test/fixtures/missing-variable-should-fallback.expected.css
@@ -1,6 +1,3 @@
-.box-foo {
-	width: undefined;
-}
 
 .box-bar {
 	width: 30px;

--- a/test/test.js
+++ b/test/test.js
@@ -204,6 +204,9 @@ describe('postcss-css-variables', function() {
 					});
 				});
 		});
+		test('should use fallback variable if provided with missing variables', 'missing-variable-should-fallback-var');
+		test('should use fallback variable if provided with missing variables calc', 'missing-variable-should-fallback-calc');
+		test('should use fallback variable if provided with missing variables nested', 'missing-variable-should-fallback-nested');
 	});
 
 	it('should not parse malformed var() declarations', function() {


### PR DESCRIPTION
Addresses issues #37 

Takes care of #39 -> https://github.com/MadLittleMods/postcss-css-variables/pull/48