### PR TITLE
Log undefined variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ module.exports = postcss.plugin('postcss-css-variables', function(options) {
 				ruleToWorkOn.nodes.slice(0).forEach(function(node) {
 					if(node.type === 'decl') {
 						var decl = node;
-						resolveDecl(decl, map, opts.preserve);
+						resolveDecl(decl, map, opts.preserve, logResolveValueResult);
 					}
 				});
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -199,6 +199,9 @@ describe('postcss-css-variables', function() {
 						var colorDecl = fooRule.nodes[0];
 						expect(colorDecl.value).to.be.a('string');
 						expect(colorDecl.value).to.be.equal('undefined');
+
+						expect(result.warnings()[0].type).to.be.equal('warning');
+                        expect(result.warnings()[0].text).to.be.equal('variable --missing is undefined and used without a fallback');
 					});
 				});
 		});

--- a/test/test.js
+++ b/test/test.js
@@ -201,7 +201,7 @@ describe('postcss-css-variables', function() {
 						expect(colorDecl.value).to.be.equal('undefined');
 
 						expect(result.warnings()[0].type).to.be.equal('warning');
-                        expect(result.warnings()[0].text).to.be.equal('variable --missing is undefined and used without a fallback');
+						expect(result.warnings()[0].text).to.be.equal('variable --missing is undefined and used without a fallback');
 					});
 				});
 		});


### PR DESCRIPTION
Fix https://github.com/MadLittleMods/postcss-css-variables/issues/31

Added `logResultValue` to log `undefined` variables