### PR TITLE
Expand variables in AtRule properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,10 @@ module.exports = postcss.plugin('postcss-css-variables', function(options) {
 
 		// Collect all the rules that have declarations that use variables
 		var rulesThatHaveDeclarationsWithVariablesList = [];
-		css.walkRules(function(rule) {
+		css.walk(function(rule) {
+			// We're only interested in Containers with children.
+			if (rule.nodes === undefined) return;
+
 			var doesRuleUseVariables = rule.nodes.some(function(node) {
 				if(node.type === 'decl') {
 					var decl = node;
@@ -234,8 +237,8 @@ module.exports = postcss.plugin('postcss-css-variables', function(options) {
 		rulesThatHaveDeclarationsWithVariablesList.forEach(function(rule) {
 			var rulesToWorkOn = [].concat(rule);
 			// Split out the rule into each comma separated selector piece
-			// We only need to split if is actually comma separted(selectors > 1)
-			if(rule.selectors.length > 1) {
+			// We only need to split if it's actually a Rule with multiple selectors
+			if(rule.type == 'rule' && rule.selectors.length > 1) {
 				// Reverse the selectors so that we can cloneAfter in the same comma separated order
 				rulesToWorkOn = rule.selectors.reverse().map(function(selector) {
 					var ruleClone = rule.cloneAfter();

--- a/test/fixtures/at-rules-containing-properties.css
+++ b/test/fixtures/at-rules-containing-properties.css
@@ -1,0 +1,8 @@
+:root {
+	--font-name: 'my-font-family-name';
+}
+
+@font-face {
+	font-family: var(--font-name);
+	src: url('myfont.woff2') format('woff2');
+}

--- a/test/fixtures/at-rules-containing-properties.expected.css
+++ b/test/fixtures/at-rules-containing-properties.expected.css
@@ -1,0 +1,4 @@
+@font-face {
+	font-family: 'my-font-family-name';
+	src: url('myfont.woff2') format('woff2');
+}

--- a/test/fixtures/nested-at-rules-containing-properties.css
+++ b/test/fixtures/nested-at-rules-containing-properties.css
@@ -1,0 +1,13 @@
+:root {
+	--color: red;
+}
+
+/*
+	Prince XML at-rules.
+	https://www.princexml.com/doc/11/at-rules/
+*/
+@page {
+	@footnote {
+		background-color: var(--color);
+	}
+}

--- a/test/fixtures/nested-at-rules-containing-properties.expected.css
+++ b/test/fixtures/nested-at-rules-containing-properties.expected.css
@@ -1,0 +1,9 @@
+/*
+	Prince XML at-rules.
+	https://www.princexml.com/doc/11/at-rules/
+*/
+@page {
+	@footnote {
+		background-color: red;
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -140,6 +140,9 @@ describe('postcss-css-variables', function() {
 		test('should work with nested @media', 'media-query-nested', { preserveAtRulesOrder: false });
 		test('should work with nested @media, preserving rule order', 'media-query-nested-preserver-rule-order', { preserveAtRulesOrder: true });
 
+		test('should work with at-rules containing properties', 'at-rules-containing-properties');
+		test('should work with nested at-rules containing properties', 'nested-at-rules-containing-properties');
+
 
 		test('should cascade to nested rules', 'cascade-on-nested-rules');
 


### PR DESCRIPTION
As written, this plugin makes the seemingly reasonable assumption that all variable expansions will happen inside of a CSS Rule (that is, a set of Properties scoped to one or more Selectors).  

However, some CSS At-Rules (like `@font-face` and `@page`) allow for CSS Properties to be their direct descendants.  These are philosophically a little trickier to implement, since (e.g.) the `@page` [At-]Rule doesn't *actually* appear in the DOM hierarchy, but not permitting At-Rules to use variables limits their utility and forces duplication of variable values.

```
:root {
  --theme-color: red;
}

body {
  color: var(--theme-color);
}

@page {
  background-color: var(--theme-color);  /* Never expanded. */
}
```

For such cases, there *is* a simple, sensible interpretation that extends naturally: `:root` implies the set of "global" variables, and the expectation is that At-Rules would have access to variables defined in that scope.  Variables defined in lower scopes should (obviously) not have an effect on such high-level [At-]Rules – and the existing behaviors for At-Rule-scoped Rules seem adequate for describing the cases where both an At-Rule and a lower-scoped variable need to coordinate.